### PR TITLE
[maintenance]: update code-sniffer to v.3.7 for better PHP8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": ">=7.2",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.7"
   },
   "bin": [
     "bin/spiral-cs"


### PR DESCRIPTION
It was detected some problems with php8.1 checks