### PR TITLE
Nullable type declaration for default null value

### DIFF
--- a/src/Rules/DefaultRules.php
+++ b/src/Rules/DefaultRules.php
@@ -117,6 +117,7 @@ final class DefaultRules implements RulesInterface
                 'syntax' => 'short',
             ],
             'ternary_to_null_coalescing' => true,
+            'nullable_type_declaration_for_default_null_value' => true, // @PHP84Migration
 
             /*
              * Rules without presets


### PR DESCRIPTION
This proposes to add `nullable_type_declaration_for_default_null_value` rule for fixing deprecation messages on PHP 8.4.